### PR TITLE
#STO-4167] - Increase probe threshold 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,7 @@ resource "azurerm_lb_probe" "azlb" {
   number_of_probes    = var.lb_probe_unhealthy_threshold
   protocol            = element(var.lb_probe[element(keys(var.lb_probe), count.index)], 0)
   request_path        = element(var.lb_probe[element(keys(var.lb_probe), count.index)], 2)
+  probe_threshold     = var.lb_probe_threshold
 }
 
 resource "azurerm_lb_rule" "azlb" {

--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,6 @@ resource "azurerm_lb_rule" "azlb" {
   backend_address_pool_ids       = [azurerm_lb_backend_address_pool.azlb.id]
   disable_outbound_snat          = var.disable_outbound_snat
   enable_floating_ip             = var.lb_floating_ip_enabled
-  idle_timeout_in_minutes        = var.azurerm_lb_rule_idle_timeout_in_minutes
+  idle_timeout_in_minutes        = var.lb_rule_idle_timeout_in_minutes
   probe_id                       = element(azurerm_lb_probe.azlb[*].id, count.index)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ variable "pip_idle_timeout_in_minutes" {
   description = "(Optional) Specifies the timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. Defaults to `4`."
 }
 
-variable "azurerm_lb_rule_idle_timeout_in_minutes" {
+variable "lb_rule_idle_timeout_in_minutes" {
   type        = number
   default     = 10
   description = "(Optional) Specifies the timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. Defaults to `4`."

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "lb_probe_interval" {
   description = "Interval in seconds the load balancer health probe rule does a check"
 }
 
+variable "lb_probe_threshold" {
+  type        = number
+  default     = 1
+  description = "The number of consecutive successful or failed probes that allow or deny traffic to this endpoint. Possible values range from 1 to 100. The default value is 1."
+}
+
 variable "lb_probe_unhealthy_threshold" {
   type        = number
   default     = 2


### PR DESCRIPTION
## Describe your changes

#STO-4167. Increase the probe threshold and fix the azurerm_lb_rule_idle_timeout_in_minutes.

This works as intended as I did a test in `tf-azure-hub`: https://github.com/venasolutions/tf-azure-hub/pull/217

![Screenshot 2025-01-28 at 10 27 36 AM](https://github.com/user-attachments/assets/29f7739e-b399-4ba3-a2ac-9266c92c3e67)


## Issue number

#STO-4167

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

